### PR TITLE
Avoid storing the template site user roles option

### DIFF
--- a/src/Template/Cloner.php
+++ b/src/Template/Cloner.php
@@ -110,6 +110,11 @@ class Cloner {
 			update_option( $key, $value );
 		}
 
+		// Override the new site's user roles with those from the source site.
+		if ( isset( $options[ $wpdb->get_blog_prefix( $this->get_template_site_id() ) . 'user_roles'] ) ) {
+			update_option( $wpdb->get_blog_prefix( $this->destination_site_id ) . 'user_roles', $options[ $wpdb->get_blog_prefix( $this->get_template_site_id() ) . 'user_roles' ] );
+		}
+
 		// add the theme mods
 		update_option( 'mods_' . $theme, $mods );
 

--- a/src/Template/Cloner.php
+++ b/src/Template/Cloner.php
@@ -79,6 +79,7 @@ class Cloner {
 			'home',
 			'upload_path',
 			'db_version',
+			$wpdb->get_blog_prefix( $this->get_template_site_id() ) . 'user_roles',
 			$wpdb->get_blog_prefix( $this->destination_site_id ) . 'user_roles',
 			'fileupload_url',
 		);


### PR DESCRIPTION
When the template site is cloned, we avoid overwriting the user roles option for the new site. This change also avoids storing the template site's user roles option, which remains as unused data in the new site's options table if stored.